### PR TITLE
v0.5.1: Fix to ExpandingBlackBody source and passing on detection criteria when filtering

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,8 @@ MAINTAINER = 'Ulrich Feindt'
 MAINTAINER_EMAIL = 'ulrich.feindt@fysik.su.se'
 URL = 'https://github.com/ufeindt/simsurvey/'
 LICENSE = 'BSD (3-clause)'
-DOWNLOAD_URL = 'https://github.com/ufeindt/simsurvey/tarball/0.5.0'
-VERSION = '0.5.0'
+DOWNLOAD_URL = 'https://github.com/ufeindt/simsurvey/tarball/0.5.1'
+VERSION = '0.5.1'
 
 try:
     from setuptools import setup, find_packages

--- a/simsurvey/__init__.py
+++ b/simsurvey/__init__.py
@@ -1,7 +1,7 @@
 
 """ Module base on astrobject, sncosmo and astropy to prepare a future survey. """
 
-__version__ = "0.5.0"
+__version__ = "0.5.1"
 
 from .simultarget import *
 from .simulsurvey import *

--- a/simsurvey/models.py
+++ b/simsurvey/models.py
@@ -159,10 +159,10 @@ class ExpandingBlackBodySource(sncosmo.Source):
             self.param_names_latex.append('R_%i'%k)
 
     def minwave(self):  
-        return 1e-100
+        return 1e2
 
     def maxwave(self):  
-        return 1e100
+        return 1e6
     
     def minphase(self):
         return self._minphase
@@ -198,12 +198,12 @@ class ExpandingBlackBodySource(sncosmo.Source):
     
     def _flux(self, phase, wave):
         wave = np.array(wave)
-        return np.array([blackbody(wave, 
-                                   T=self.temperature(p_),
-                                   R=self.radius(p_),
-                                   d=self._parameters[0]) 
-                         for p_ in phase])
-
+        out = [np.pi*blackbody(wave, T=self.temperature(p_))
+               * (self.radius(p_)*6.957e8/(self._parameters[0]*3.0857e24))**2 
+               for p_ in phase]
+        
+        return np.array(out)
+    
 class SpectralIndexSource(sncosmo.Source):
     """
     """
@@ -269,11 +269,11 @@ class SpectralIndexSource(sncosmo.Source):
 # Auxilary functions                  #
 #                                     #
 #######################################
-def blackbody(wl, T=6e3, R=1., d=1e-5):
+def blackbody(wl, T=6e3):
     # wl in Ångströms
     # T in Kelvin
     # R in solar radii
     # d in Mpc
     # output in erg s^-1 cm^-2 Angstrom^-1
-    B = 1.19104295262e+27 * wl**-5 / (np.exp(1.43877735383e+8 / (wl*T)) - 1)
-    return B * (R*6.957e8 / (d*3.0857e22))**2
+    return 1.19104295262e+27 * wl**-5 / (np.exp(1.43877735383e+8 / (wl*T)) - 1)
+    

--- a/simsurvey/models.py
+++ b/simsurvey/models.py
@@ -199,7 +199,7 @@ class ExpandingBlackBodySource(sncosmo.Source):
     def _flux(self, phase, wave):
         wave = np.array(wave)
         out = [np.pi*blackbody(wave, T=self.temperature(p_))
-               * (self.radius(p_)*6.957e8/(self._parameters[0]*3.0857e24))**2 
+               * (self.radius(p_)/self._parameters[0]*2.25459e-14)**2 
                for p_ in phase]
         
         return np.array(out)

--- a/simsurvey/simulsurvey.py
+++ b/simsurvey/simulsurvey.py
@@ -1031,13 +1031,19 @@ class LightcurveCollection( BaseObject ):
         os.rmdir(tmpdir)
         os.chdir(cwd)
         
-    def filter(self, filterfunc):
+    def filter(self, filterfunc, n_det=None, threshold=None):
         """Create new LightcurveCollection, where each lc
         is filtered using filterfunc which takes the lc as an argument
         If the lc is empty due to filtering or None, it is not added
         to the collection
         """
-        lcs = LightcurveCollection(empty=True)
+        if n_det is None:
+            n_det = self.n_det
+
+        if threshold is None:
+            threshold = self.threshold
+        
+        lcs = LightcurveCollection(empty=True, n_det=n_det, threshold=threshold)
         
         for k in range(len(self.lcs)):
             lc = self._get_lc_(k)


### PR DESCRIPTION
ExpandingBlackBody source was missing a factor pi in the flux, which has been fixed now.

Further the criteria for keeping a lightcurve would revert to the default if the LCs were filtered (e.g. throwing out points in bad nights). Now, the LightcurveCollection's settings are retained unless they are changed when calling LightcurveCollection.filter()